### PR TITLE
Add and apply clang-format settings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+DerivePointerAlignment: false
+PointerAlignment: Right
+SpaceBeforeParens: ControlStatements
+SpacesBeforeTrailingComments: 1
+UseTab: Never
+AllowShortFunctionsOnASingleLine: false
+BreakBeforeBraces: Stroustrup
+ColumnLimit: 79
+BinPackParameters: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Straightforward password-based file encryption on the UNIX command line
 
 ## Copyright and License
 
-Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
 
 This software is released under the ISC license. See the `LICENSE` file for
 more details.

--- a/src/crypto/machine/endian.h
+++ b/src/crypto/machine/endian.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -46,10 +46,12 @@
  */
 static inline void put_big_end_32(byte_t *location, uint32_t value)
 {
+    /* clang-format off */
     location[0] = (byte_t)((value >> 24) & 0xFF);
     location[1] = (byte_t)((value >> 16) & 0xFF);
     location[2] = (byte_t)((value >>  8) & 0xFF);
     location[3] = (byte_t)((value      ) & 0xFF);
+    /* clang-format on */
 }
 
 /*
@@ -60,6 +62,7 @@ static inline void put_big_end_32(byte_t *location, uint32_t value)
  */
 static inline void put_big_end_64(byte_t *location, uint64_t value)
 {
+    /* clang-format off */
     location[0] = (byte_t)((value >> 56) & 0xFF);
     location[1] = (byte_t)((value >> 48) & 0xFF);
     location[2] = (byte_t)((value >> 40) & 0xFF);
@@ -68,6 +71,7 @@ static inline void put_big_end_64(byte_t *location, uint64_t value)
     location[5] = (byte_t)((value >> 16) & 0xFF);
     location[6] = (byte_t)((value >>  8) & 0xFF);
     location[7] = (byte_t)((value      ) & 0xFF);
+    /* clang-format on */
 }
 
 /*
@@ -78,10 +82,12 @@ static inline void put_big_end_64(byte_t *location, uint64_t value)
  */
 static inline void put_little_end_32(byte_t *location, uint32_t value)
 {
+    /* clang-format off */
     location[0] = (byte_t)((value      ) & 0xFF);
     location[1] = (byte_t)((value >>  8) & 0xFF);
     location[2] = (byte_t)((value >> 16) & 0xFF);
     location[3] = (byte_t)((value >> 24) & 0xFF);
+    /* clang-format on */
 }
 
 /*
@@ -92,6 +98,7 @@ static inline void put_little_end_32(byte_t *location, uint32_t value)
  */
 static inline void put_little_end_64(byte_t *location, uint64_t value)
 {
+    /* clang-format off */
     location[0] = (byte_t)((value      ) & 0xFF);
     location[1] = (byte_t)((value >>  8) & 0xFF);
     location[2] = (byte_t)((value >> 16) & 0xFF);
@@ -100,6 +107,7 @@ static inline void put_little_end_64(byte_t *location, uint64_t value)
     location[5] = (byte_t)((value >> 40) & 0xFF);
     location[6] = (byte_t)((value >> 48) & 0xFF);
     location[7] = (byte_t)((value >> 56) & 0xFF);
+    /* clang-format on */
 }
 
 /*
@@ -111,10 +119,12 @@ static inline void put_little_end_64(byte_t *location, uint64_t value)
  */
 static inline uint32_t get_big_end_32(const byte_t *location)
 {
+    /* clang-format off */
     return (((uint32_t)(location[0])) << 24) |
            (((uint32_t)(location[1])) << 16) |
            (((uint32_t)(location[2])) <<  8) |
            (((uint32_t)(location[3]))      );
+    /* clang-format on */
 }
 
 /*
@@ -126,6 +136,7 @@ static inline uint32_t get_big_end_32(const byte_t *location)
  */
 static inline uint64_t get_big_end_64(const byte_t *location)
 {
+    /* clang-format off */
     return (((uint64_t)(location[0])) << 56) |
            (((uint64_t)(location[1])) << 48) |
            (((uint64_t)(location[2])) << 40) |
@@ -134,6 +145,7 @@ static inline uint64_t get_big_end_64(const byte_t *location)
            (((uint64_t)(location[5])) << 16) |
            (((uint64_t)(location[6])) <<  8) |
            (((uint64_t)(location[7]))      );
+    /* clang-format on */
 }
 
 /*
@@ -145,10 +157,12 @@ static inline uint64_t get_big_end_64(const byte_t *location)
  */
 static inline uint32_t get_little_end_32(const byte_t *location)
 {
+    /* clang-format off */
     return (((uint32_t)(location[0]))      ) |
            (((uint32_t)(location[1])) <<  8) |
            (((uint32_t)(location[2])) << 16) |
            (((uint32_t)(location[3])) << 24);
+    /* clang-format on */
 }
 
 /*
@@ -160,6 +174,7 @@ static inline uint32_t get_little_end_32(const byte_t *location)
  */
 static inline uint64_t get_little_end_64(const byte_t *location)
 {
+    /* clang-format off */
     return (((uint64_t)(location[0]))      ) |
            (((uint64_t)(location[1])) <<  8) |
            (((uint64_t)(location[2])) << 16) |
@@ -168,6 +183,7 @@ static inline uint64_t get_little_end_64(const byte_t *location)
            (((uint64_t)(location[5])) << 40) |
            (((uint64_t)(location[6])) << 48) |
            (((uint64_t)(location[7])) << 56);
+    /* clang-format on */
 }
 
 #endif

--- a/src/crypto/primitives/aes/aes_ecb.c
+++ b/src/crypto/primitives/aes/aes_ecb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2011-2024 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -795,10 +795,12 @@ void aes_ecb_encrypt(struct aes_ecb_ctx *ctx, const byte_t *block,
     size_t i;
 
     /* AddRoundKey() before any rounds begin */
+    /* clang-format off */
     col0 = get_big_end_32(block     ) ^ *(rk++);
     col1 = get_big_end_32(block +  4) ^ *(rk++);
     col2 = get_big_end_32(block +  8) ^ *(rk++);
     col3 = get_big_end_32(block + 12) ^ *(rk++);
+    /* clang-format on */
 
     /* All but the last round perform all four operations */
     for (i = 0; i < ctx->nr - 1; i++) {
@@ -812,6 +814,7 @@ void aes_ecb_encrypt(struct aes_ecb_ctx *ctx, const byte_t *block,
     }
 
     /* Last round only performs ShiftRows(), SubBytes(), and AddRoundKey() */
+    /* clang-format off */
     put_big_end_32(output     ,
                    column_enc_no_mix(col0, col1, col2, col3, *(rk++)));
     put_big_end_32(output +  4,
@@ -820,6 +823,7 @@ void aes_ecb_encrypt(struct aes_ecb_ctx *ctx, const byte_t *block,
                    column_enc_no_mix(col2, col3, col0, col1, *(rk++)));
     put_big_end_32(output + 12,
                    column_enc_no_mix(col3, col0, col1, col2, *(rk  )));
+    /* clang-format on */
 }
 
 void aes_ecb_decrypt(struct aes_ecb_ctx *ctx, const byte_t *block,
@@ -831,10 +835,12 @@ void aes_ecb_decrypt(struct aes_ecb_ctx *ctx, const byte_t *block,
     size_t i;
 
     /* AddRoundKey() before any rounds begin */
+    /* clang-format off */
     col0 = get_big_end_32(block     ) ^ *(rk++);
     col1 = get_big_end_32(block +  4) ^ *(rk++);
     col2 = get_big_end_32(block +  8) ^ *(rk++);
     col3 = get_big_end_32(block + 12) ^ *(rk++);
+    /* clang-format on */
 
     /* All but the last round perform all four operations */
     for (i = 0; i < ctx->nr - 1; i++) {
@@ -851,6 +857,7 @@ void aes_ecb_decrypt(struct aes_ecb_ctx *ctx, const byte_t *block,
      * Last round only performs InvShiftRows(), InvSubBytes(), and
      * AddRoundKey()
      */
+    /* clang-format off */
     put_big_end_32(output     ,
                    column_dec_no_mix(col0, col3, col2, col1, *(rk++)));
     put_big_end_32(output +  4,
@@ -859,6 +866,7 @@ void aes_ecb_decrypt(struct aes_ecb_ctx *ctx, const byte_t *block,
                    column_dec_no_mix(col2, col1, col0, col3, *(rk++)));
     put_big_end_32(output + 12,
                    column_dec_no_mix(col3, col2, col1, col0, *(rk  )));
+    /* clang-format on */
 }
 
 void aes_ecb_free_scrub(struct aes_ecb_ctx *ctx)
@@ -872,57 +880,69 @@ void aes_ecb_free_scrub(struct aes_ecb_ctx *ctx)
 static inline uint32_t column_enc(uint32_t top, uint32_t second,
                                   uint32_t third, uint32_t fourth, uint32_t rk)
 {
+    /* clang-format off */
     return rk ^
            SUB_MIX_ENC_POS0[(top    >> 24) & 0xFF] ^
            SUB_MIX_ENC_POS1[(second >> 16) & 0xFF] ^
            SUB_MIX_ENC_POS2[(third  >>  8) & 0xFF] ^
            SUB_MIX_ENC_POS3[(fourth      ) & 0xFF];
+    /* clang-format on */
 }
 
 static inline uint32_t column_enc_no_mix(uint32_t top, uint32_t second,
                                          uint32_t third, uint32_t fourth,
                                          uint32_t rk)
 {
+    /* clang-format off */
     return rk ^
            (((uint32_t)(S_BOX_ENC[(top    >> 24) & 0xFF])) << 24) ^
            (((uint32_t)(S_BOX_ENC[(second >> 16) & 0xFF])) << 16) ^
            (((uint32_t)(S_BOX_ENC[(third  >>  8) & 0xFF])) <<  8) ^
            (((uint32_t)(S_BOX_ENC[(fourth      ) & 0xFF]))      );
+    /* clang-format on */
 }
 
 static inline uint32_t sbox_enc_word(uint32_t orig)
 {
+    /* clang-format off */
     return (((uint32_t)(S_BOX_ENC[(orig      ) & 0xFF]))      ) |
            (((uint32_t)(S_BOX_ENC[(orig >>  8) & 0xFF])) <<  8) |
            (((uint32_t)(S_BOX_ENC[(orig >> 16) & 0xFF])) << 16) |
            (((uint32_t)(S_BOX_ENC[(orig >> 24) & 0xFF])) << 24);
+    /* clang-format on */
 }
 
 static inline uint32_t column_dec(uint32_t top, uint32_t second,
                                   uint32_t third, uint32_t fourth, uint32_t rk)
 {
+    /* clang-format off */
     return rk ^
            SUB_MIX_DEC_POS0[(top    >> 24) & 0xFF] ^
            SUB_MIX_DEC_POS1[(second >> 16) & 0xFF] ^
            SUB_MIX_DEC_POS2[(third  >>  8) & 0xFF] ^
            SUB_MIX_DEC_POS3[(fourth      ) & 0xFF];
+    /* clang-format on */
 }
 
 static inline uint32_t column_dec_no_mix(uint32_t top, uint32_t second,
                                          uint32_t third, uint32_t fourth,
                                          uint32_t rk)
 {
+    /* clang-format off */
     return rk ^
            (((uint32_t)(S_BOX_DEC[(top    >> 24) & 0xFF])) << 24) ^
            (((uint32_t)(S_BOX_DEC[(second >> 16) & 0xFF])) << 16) ^
            (((uint32_t)(S_BOX_DEC[(third  >>  8) & 0xFF])) <<  8) ^
            (((uint32_t)(S_BOX_DEC[(fourth      ) & 0xFF]))      );
+    /* clang-format on */
 }
 
 static inline uint32_t inv_mix_column(uint32_t col)
 {
+    /* clang-format off */
     return MIX_DEC_POS0[(col >> 24) & 0xFF] ^
            MIX_DEC_POS1[(col >> 16) & 0xFF] ^
            MIX_DEC_POS2[(col >>  8) & 0xFF] ^
            MIX_DEC_POS3[(col      ) & 0xFF];
+    /* clang-format on */
 }

--- a/src/pisces/version.c
+++ b/src/pisces/version.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -98,5 +98,5 @@ struct kdf *pisces_kdf_alloc()
         return kdf_alloc(KDF_ALG_PBKDF2_HMAC_SHA3_512_16384);
     default:
         FATAL_ERROR("Illegal Pisces version");
-     }
+    }
 }


### PR DESCRIPTION
Add a `.clang-format` settings file; place exceptions into portions of the code where the formatting is intended to be non-standard (for readability); and, fix one file where the settings hadn't been applied properly.