### PR TITLE
Use size_t for size types in AES tests

### DIFF
--- a/src/crypto/primitives/aes/test_aes_cbc.c
+++ b/src/crypto/primitives/aes/test_aes_cbc.c
@@ -18,6 +18,7 @@
 #include "crypto/primitives/aes/aes_cbc.h"
 #include "crypto/test/framework.h"
 
+#include <stddef.h>
 #include <string.h>
 
 TEST_PREAMBLE("AES-CBC");
@@ -37,7 +38,7 @@ struct aes_cbc_ctx *ctx;
 #define TEST_NUM_BLOCKS_MAX (4)
 struct aes_cbc_plain_test {
     const int keySize;
-    const int numBlocks;
+    const size_t numBlocks;
     const byte_t key[AES_CBC_KEY_SIZE_MAX];
     const byte_t iv[AES_CBC_IV_SIZE];
     const byte_t plaintext[AES_CBC_BLOCK_SIZE * TEST_NUM_BLOCKS_MAX];
@@ -51,7 +52,7 @@ struct aes_cbc_plain_test {
  */
 struct aes_cbc_monte_test {
     const int direction;
-    const int keySize;
+    const size_t keySize;
     const byte_t key[AES_CBC_KEY_SIZE_MAX];
     const byte_t iv[AES_CBC_IV_SIZE];
     const byte_t plaintext[AES_CBC_BLOCK_SIZE];
@@ -376,7 +377,7 @@ static const struct aes_cbc_monte_test monteTests[] = {
  */
 int main()
 {
-    int onTest;
+    size_t onTest;
     ctx = aes_cbc_alloc();
 
     for (onTest = 0;
@@ -399,7 +400,7 @@ int main()
 static void run_aes_cbc_plain_test(const struct aes_cbc_plain_test *test,
                                    int direction)
 {
-    int onBlock;
+    size_t onBlock;
     byte_t actual[AES_CBC_BLOCK_SIZE * TEST_NUM_BLOCKS_MAX];
     memset(actual, 0, AES_CBC_BLOCK_SIZE * TEST_NUM_BLOCKS_MAX);
 

--- a/src/crypto/primitives/aes/test_aes_ecb.c
+++ b/src/crypto/primitives/aes/test_aes_ecb.c
@@ -18,6 +18,7 @@
 #include "crypto/primitives/aes/aes_ecb.h"
 #include "crypto/test/framework.h"
 
+#include <stddef.h>
 #include <string.h>
 
 TEST_PREAMBLE("AES-ECB");
@@ -30,7 +31,7 @@ struct aes_ecb_ctx *ctx;
 #define TEST_TYPE_NIST_MONTE_LOOP (1)
 struct aes_ecb_test {
     const int type;
-    const int keySize;
+    const size_t keySize;
     const byte_t key[AES_ECB_KEY_SIZE_MAX];
     const byte_t plaintext[AES_ECB_BLOCK_SIZE];
     const byte_t ciphertext[AES_ECB_BLOCK_SIZE];
@@ -355,7 +356,7 @@ static const struct aes_ecb_test allTests[] = {
  */
 int main()
 {
-    int onTest;
+    size_t onTest;
     ctx = aes_ecb_alloc();
 
     for (onTest = 0; onTest < sizeof(allTests) / sizeof(struct aes_ecb_test);


### PR DESCRIPTION
The tests for AES-ECB and AES-CBC incorrectly used `int` instead of `size_t` for some variables involving sizes. There was no problem with using `int` because of the small size and number of tests, but the type was incorrect nonetheless.