### PR TITLE
Convert AES-ECB test vector inputs to hex strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test: ${BINDIR}/test_aes_ecb ${BINDIR}/test_aes_cbc ${BINDIR}/test_sha1 \
 ##
 
 TEST_AES_ECB_OBJS = src/crypto/primitives/aes/test_aes_ecb.o \
-  src/crypto/primitives/aes/aes_ecb.o
+  src/crypto/primitives/aes/aes_ecb.o src/crypto/test/hex.o
 
 ${BINDIR}/test_aes_ecb: ${TEST_AES_ECB_OBJS}
 	${CC} ${CFLAGS} -o $@ ${TEST_AES_ECB_OBJS}
@@ -230,6 +230,8 @@ src/crypto/abstract/cipher.o: src/crypto/abstract/cipher.c \
   src/common/errorflow.h src/common/scrub.h \
   src/crypto/algorithms/pkcs7/pkcs7_padding.h \
   src/crypto/primitives/aes/aes_cbc.h
+src/crypto/test/hex.o: src/crypto/test/hex.c src/crypto/test/hex.h \
+  src/common/bytetype.h src/common/errorflow.h
 src/crypto/algorithms/hmac/hmac.o: src/crypto/algorithms/hmac/hmac.c \
   src/crypto/algorithms/hmac/hmac.h src/common/bytetype.h \
   src/crypto/abstract/chf.h src/common/errorflow.h src/common/scrub.h
@@ -268,7 +270,8 @@ src/crypto/primitives/sha1/sha1.o: src/crypto/primitives/sha1/sha1.c \
   src/crypto/machine/endian.h
 src/crypto/primitives/aes/test_aes_ecb.o: \
   src/crypto/primitives/aes/test_aes_ecb.c src/common/bytetype.h \
-  src/crypto/primitives/aes/aes_ecb.h src/crypto/test/framework.h
+  src/common/errorflow.h src/crypto/primitives/aes/aes_ecb.h \
+  src/crypto/test/framework.h src/crypto/test/hex.h
 src/crypto/primitives/aes/aes_cbc.o: src/crypto/primitives/aes/aes_cbc.c \
   src/crypto/primitives/aes/aes_cbc.h src/common/bytetype.h \
   src/common/errorflow.h src/common/scrub.h \

--- a/src/crypto/test/hex.c
+++ b/src/crypto/test/hex.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Ryan Vogt <rvogt.ca@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "hex.h"
+
+#include "common/bytetype.h"
+#include "common/errorflow.h"
+
+#include <stddef.h>
+#include <string.h>
+
+/*
+ * Returns the number of bytes represented by the given hexadecimal string. It
+ * is a fatal error for the length of the hex string to be greater than
+ * HEX_TO_BYTES_MAX_STRLEN or to be odd.
+ */
+static size_t hex_byte_len(const char *hex);
+
+void hex_to_bytes(const char *hex, byte_t **bytes, size_t *numBytes)
+{
+    size_t outLen;
+    byte_t *out;
+    unsigned int byteVal;
+
+    outLen = hex_byte_len(hex);
+    out = (byte_t *)calloc(outLen, 1);
+    ASSERT_ALLOC(out);
+
+    *numBytes = outLen;
+    *bytes = out;
+
+    while (outLen > 0) {
+        if (sscanf(hex, "%2x", &byteVal) != 1) {
+            FATAL_ERROR("Invalid value in hexadecimal string");
+        }
+        *out++ = (byte_t)byteVal;
+        hex += 2;
+        outLen--;
+    }
+}
+
+static size_t hex_byte_len(const char *hex)
+{
+    size_t inLen;
+
+    inLen = strnlen(hex, HEX_TO_BYTES_MAX_STRLEN + 1);
+
+    ASSERT(inLen != HEX_TO_BYTES_MAX_STRLEN + 1,
+           "Input hexadecimal string too long: %zu", inLen);
+    ASSERT(inLen % 2 == 0, "Input hexadecimal string has odd length: %zu",
+           inLen);
+
+    return inLen / 2;
+}

--- a/src/crypto/test/hex.h
+++ b/src/crypto/test/hex.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Ryan Vogt <rvogt.ca@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef PISCES_CRYPTO_TEST_HEX_H_
+#define PISCES_CRYPTO_TEST_HEX_H_
+
+#include "common/bytetype.h"
+
+#include <stddef.h>
+
+/*
+ * The largest input string size accepted by hex_to_bytes(), and the largest
+ * possible number of bytes output by that function.
+ */
+#define HEX_TO_BYTES_MAX_STRLEN (1000)
+#define HEX_TO_BYTES_MAX_NUM_BYTES (HEX_TO_BYTES_MAX_STRLEN / 2)
+
+/*
+ * Converts a string of hexadecimal characters to an array of bytes. The string
+ * must contain only the characters 0-9 and A-F (or a-f), with no prefix of
+ * "0x".
+ *
+ * A new array will be allocated and used to store the bytes, in *bytes. The
+ * caller will be responsible for freeing it. The size of the allocated array
+ * will be stored in *numBytes.
+ */
+void hex_to_bytes(const char *hex, byte_t **bytes, size_t *numBytes);
+
+#endif


### PR DESCRIPTION
This pull request represents the first step in converting the cryptographic test framework from using byte array test vectors to using hexadecimal string test vectors. The benefit of using hexadecimal strings (instead of byte arrays) as test vector inputs isn't immediately obvious from the change to the AES-ECB tests. However, it will greatly simplify the testing of algorithms with multiple arbitrary-length inputs (e.g., HMAC and PBKDF2).