### PR TITLE
Convert PBKDF2 test vector inputs to hex strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ ${BINDIR}/test_hmac: ${TEST_HMAC_OBJS}
 TEST_PBKDF2_OBJS = src/crypto/algorithms/pbkdf2/test_pbkdf2.o \
   src/crypto/algorithms/pbkdf2/pbkdf2.o src/crypto/algorithms/hmac/hmac.o \
   src/crypto/abstract/chf.o src/crypto/primitives/sha1/sha1.o \
-  src/crypto/primitives/sha3/sha3.o
+  src/crypto/primitives/sha3/sha3.o src/crypto/test/hex.o
 
 ${BINDIR}/test_pbkdf2: ${TEST_PBKDF2_OBJS}
 	${CC} ${CFLAGS} -o $@ ${TEST_PBKDF2_OBJS}
@@ -252,8 +252,9 @@ src/crypto/algorithms/hmac/test_hmac.o: \
   src/crypto/test/hex.h
 src/crypto/algorithms/pbkdf2/test_pbkdf2.o: \
   src/crypto/algorithms/pbkdf2/test_pbkdf2.c src/common/bytetype.h \
-  src/crypto/abstract/chf.h src/crypto/algorithms/pbkdf2/pbkdf2.h \
-  src/crypto/test/framework.h
+  src/common/errorflow.h src/crypto/abstract/chf.h \
+  src/crypto/algorithms/pbkdf2/pbkdf2.h src/crypto/test/framework.h \
+  src/crypto/test/hex.h
 src/crypto/algorithms/pbkdf2/pbkdf2.o: \
   src/crypto/algorithms/pbkdf2/pbkdf2.c \
   src/crypto/algorithms/pbkdf2/pbkdf2.h src/common/bytetype.h \

--- a/src/crypto/algorithms/pbkdf2/test_pbkdf2.c
+++ b/src/crypto/algorithms/pbkdf2/test_pbkdf2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2023-2024 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -15,121 +15,164 @@
  */
 
 #include "common/bytetype.h"
+#include "common/errorflow.h"
 #include "crypto/abstract/chf.h"
 #include "crypto/algorithms/pbkdf2/pbkdf2.h"
 #include "crypto/test/framework.h"
+#include "crypto/test/hex.h"
 
+#include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 TEST_PREAMBLE("PBKDF2");
 
 /*
- * Test an execution of PBKDF2 SHA-1 where the derived key is the length of the
- * hash output, and only a single iteration is used.
- *
- * Expected results are from RFC 6070, P with 8 octets, S with 4 octets, c=1,
- * dkLen=20.
+ * Parameters for testing the output of a single invocation of the PBKDF2
+ * algorithm.
  */
-static void test_single_cycle(void)
-{
-    const byte_t password[] = {0x70, 0x61, 0x73, 0x73, 0x77, 0x6F, 0x72, 0x64};
-    const byte_t salt[] = {0x73, 0x61, 0x6C, 0x74};
-    const unsigned int c = 1;
-    const byte_t expected[] = {0x0C, 0x60, 0xC8, 0x0F, 0x96, 0x1F, 0x0E,
-                               0x71, 0xF3, 0xA9, 0xB5, 0x24, 0xAF, 0x60,
-                               0x12, 0x06, 0x2F, 0xE0, 0x37, 0xA6};
-    byte_t actual[sizeof(expected)];
-
-    memset(actual, 0, sizeof(actual));
-    pbkdf2_hmac(actual, sizeof(actual), (const char *)password,
-                sizeof(password), salt, sizeof(salt), c, CHF_ALG_SHA1);
-    TEST_ASSERT(memcmp(actual, expected, sizeof(expected)) == 0);
-}
+struct pbkdf2_test {
+    chf_algorithm_t hashAlg;
+    unsigned int iterationCount;
+    const char *password;
+    const char *salt;
+    const char *derivedKey;
+};
 
 /*
- * Test an execution of PBKDF2 SHA-1 where the derived key is the length of the
- * hash output, and multiple iterations are used.
- *
- * Expected results are from RFC 6070, P with 8 octets, S with 4 octets,
- * c=4096, dkLen=20.
+ * Runs a PBKDF2 test, and asserts that the actual derived key matches the
+ * expected derived key in the given test parameters.
  */
-static void test_multiple_cycles(void)
-{
-    const byte_t password[] = {0x70, 0x61, 0x73, 0x73, 0x77, 0x6F, 0x72, 0x64};
-    const byte_t salt[] = {0x73, 0x61, 0x6C, 0x74};
-    const unsigned int c = 4096;
-    const byte_t expected[] = {0x4B, 0x00, 0x79, 0x01, 0xB7, 0x65, 0x48,
-                               0x9A, 0xBE, 0xAD, 0x49, 0xD9, 0x26, 0xF7,
-                               0x21, 0xD0, 0x65, 0xA4, 0x29, 0xC1};
-    byte_t actual[sizeof(expected)];
-
-    memset(actual, 0, sizeof(actual));
-    pbkdf2_hmac(actual, sizeof(actual), (const char *)password,
-                sizeof(password), salt, sizeof(salt), c, CHF_ALG_SHA1);
-    TEST_ASSERT(memcmp(actual, expected, sizeof(expected)) == 0);
-}
+static void run_pbkdf2_test(const struct pbkdf2_test *test);
 
 /*
- * Test an execution of PBKDF2 SHA-1 where the derived key is shorter than the
- * length of the hash output, and multiple iterations are used.
- *
- * Expected results are from RFC 6070, P with 9 octets, S with 5 octets,
- * c=4096, dkLen=16.
+ * Runs a PBKDF2 test that has been parsed from its hexadecimal string format.
  */
-static void test_dk_shorter_than_hlen(void)
-{
-    const byte_t password[] = {0x70, 0x61, 0x73, 0x73, 0x00,
-                               0x77, 0x6F, 0x72, 0x64};
-    const byte_t salt[] = {0x73, 0x61, 0x00, 0x6C, 0x74};
-    const unsigned int c = 4096;
-    const byte_t expected[] = {0x56, 0xFA, 0x6A, 0xA7, 0x55, 0x48, 0x09, 0x9D,
-                               0xCC, 0x37, 0xD7, 0xF0, 0x34, 0x25, 0xE0, 0xC3};
-    byte_t actual[sizeof(expected)];
-
-    memset(actual, 0, sizeof(actual));
-    pbkdf2_hmac(actual, sizeof(actual), (const char *)password,
-                sizeof(password), salt, sizeof(salt), c, CHF_ALG_SHA1);
-    TEST_ASSERT(memcmp(actual, expected, sizeof(expected)) == 0);
-}
+static void run_parsed_pbkdf2_test(chf_algorithm_t hashAlg,
+                                   unsigned int iterationCount,
+                                   const byte_t *password, size_t passwordLen,
+                                   const byte_t *salt, size_t saltLen,
+                                   const byte_t *derivedKey,
+                                   size_t derivedKeyLen);
 
 /*
- * Test an execution of PBKDF2 SHA-1 where the derived key is longer than the
- * length of the hash output, and multiple iterations are used.
- *
- * Expected results are from RFC 6070, P with 24 octets, S with 36 octets,
- * c=4096, dkLen=25.
+ * All of the official tests (from RFC 6070) to run for PBKDF2. The fourth test
+ * vector, with an iteration count of 16777216, is intentionally omitted
+ * because of the time it takes to run.
  */
-static void test_dk_larger_than_hlen(void)
-{
-    const byte_t password[] = {0x70, 0x61, 0x73, 0x73, 0x77, 0x6F, 0x72, 0x64,
-                               0x50, 0x41, 0x53, 0x53, 0x57, 0x4F, 0x52, 0x44,
-                               0x70, 0x61, 0x73, 0x73, 0x77, 0x6F, 0x72, 0x64};
-    const byte_t salt[] = {0x73, 0x61, 0x6C, 0x74, 0x53, 0x41, 0x4C, 0x54,
-                           0x73, 0x61, 0x6C, 0x74, 0x53, 0x41, 0x4C, 0x54,
-                           0x73, 0x61, 0x6C, 0x74, 0x53, 0x41, 0x4C, 0x54,
-                           0x73, 0x61, 0x6C, 0x74, 0x53, 0x41, 0x4C, 0x54,
-                           0x73, 0x61, 0x6C, 0x74};
-    const unsigned int c = 4096;
-    const byte_t expected[] = {0x3D, 0x2E, 0xEC, 0x4F, 0xE4, 0x1C, 0x84,
-                               0x9B, 0x80, 0xC8, 0xD8, 0x36, 0x62, 0xC0,
-                               0xE4, 0x4A, 0x8B, 0x29, 0x1A, 0x96, 0x4C,
-                               0xF2, 0xF0, 0x70, 0x38};
-    byte_t actual[sizeof(expected)];
+#define RUN_RFC_6070_TEST_VECTOR_FOUR (0)
+static const struct pbkdf2_test allTests[] = {
+    /* RFC 6070, first test vector, with P="password" and S="salt" */
+    {
+        .hashAlg = CHF_ALG_SHA1,
+        .iterationCount = 1,
+        .password = "70617373776F7264",
+        .salt = "73616C74",
+        .derivedKey = "0C60C80F961F0E71F3A9B524AF6012062FE037A6",
+    },
 
-    memset(actual, 0, sizeof(actual));
-    pbkdf2_hmac(actual, sizeof(actual), (const char *)password,
-                sizeof(password), salt, sizeof(salt), c, CHF_ALG_SHA1);
-    TEST_ASSERT(memcmp(actual, expected, sizeof(expected)) == 0);
-}
+    /* RFC 6070, second test vector, with P="password" and S="salt" */
+    {
+        .hashAlg = CHF_ALG_SHA1,
+        .iterationCount = 2,
+        .password = "70617373776F7264",
+        .salt = "73616C74",
+        .derivedKey = "EA6C014DC72D6F8CCD1ED92ACE1D41F0D8DE8957",
+    },
+
+    /* RFC 6070, third test vector, with P="password" and S="salt" */
+    {
+        .hashAlg = CHF_ALG_SHA1,
+        .iterationCount = 4096,
+        .password = "70617373776F7264",
+        .salt = "73616C74",
+        .derivedKey = "4B007901B765489ABEAD49D926F721D065A429C1",
+    },
+
+#if RUN_RFC_6070_TEST_VECTOR_FOUR
+    /*
+     * RFC 6070, fourth test vector, with P="password" and S="salt", and a very
+     * high iteration count.
+     */
+    {
+        .hashAlg = CHF_ALG_SHA1,
+        .iterationCount = 16777216,
+        .password = "70617373776F7264",
+        .salt = "73616C74",
+        .derivedKey = "EEFE3D61CD4DA4E4E9945B3D6BA2158C2634E984",
+    },
+#endif /* RUN_RFC_6070_TEST_VECTOR_FOUR */
+
+    /*
+     * RFC 6070, fifth test vector, with P="passwordPASSWORDpassword" and
+     * S="saltSALTsaltSALTsaltSALTsaltSALTsalt".
+     */
+    {
+        .hashAlg = CHF_ALG_SHA1,
+        .iterationCount = 4096,
+        .password = "70617373776F726450415353574F524470617373776F7264",
+        .salt = "73616C7453414C5473616C7453414C5473616C7453414C5473616C7453414"
+                "C5473616C74",
+        .derivedKey = "3D2EEC4FE41C849B80C8D83662C0E44A8B291A964CF2F07038",
+    },
+
+    /* RFC 6070, sixth test vector, with P="pass\0word" and S="sa\0lt" */
+    {
+        .hashAlg = CHF_ALG_SHA1,
+        .iterationCount = 4096,
+        .password = "7061737300776F7264",
+        .salt = "7361006C74",
+        .derivedKey = "56FA6AA75548099DCC37D7F03425E0C3",
+    },
+};
 
 /*
  * Run the PBKDF2 tests and report the success rate.
  */
 int main()
 {
-    test_single_cycle();
-    test_multiple_cycles();
-    test_dk_shorter_than_hlen();
-    test_dk_larger_than_hlen();
+    size_t onTest;
+
+    for (onTest = 0; onTest < sizeof(allTests) / sizeof(struct pbkdf2_test);
+         onTest++) {
+        run_pbkdf2_test(&allTests[onTest]);
+    }
+
     TEST_CONCLUDE();
+}
+
+static void run_pbkdf2_test(const struct pbkdf2_test *test)
+{
+    byte_t *password, *salt, *derivedKey;
+    size_t passwordLen, saltLen, derivedKeyLen;
+
+    hex_to_bytes(test->password, &password, &passwordLen);
+    hex_to_bytes(test->salt, &salt, &saltLen);
+    hex_to_bytes(test->derivedKey, &derivedKey, &derivedKeyLen);
+
+    run_parsed_pbkdf2_test(test->hashAlg, test->iterationCount, password,
+                           passwordLen, salt, saltLen, derivedKey,
+                           derivedKeyLen);
+
+    free(password);
+    free(salt);
+    free(derivedKey);
+}
+
+static void run_parsed_pbkdf2_test(chf_algorithm_t hashAlg,
+                                   unsigned int iterationCount,
+                                   const byte_t *password, size_t passwordLen,
+                                   const byte_t *salt, size_t saltLen,
+                                   const byte_t *derivedKey,
+                                   size_t derivedKeyLen)
+{
+    byte_t *actual;
+    actual = calloc(1, derivedKeyLen);
+    ASSERT_ALLOC(actual);
+
+    pbkdf2_hmac(actual, derivedKeyLen, (const char *)password, passwordLen,
+                salt, saltLen, iterationCount, hashAlg);
+
+    TEST_ASSERT(memcmp(actual, derivedKey, derivedKeyLen) == 0);
+    free(actual);
 }


### PR DESCRIPTION
This pull request completes the conversion of test vector inputs into hexadecimal-character strings, started with #15, #16, #18, #20, and #21.