### PR TITLE
Fix missing includes for free(3) and size_t

### DIFF
--- a/src/crypto/algorithms/hmac/test_hmac.c
+++ b/src/crypto/algorithms/hmac/test_hmac.c
@@ -21,6 +21,8 @@
 #include "crypto/test/framework.h"
 #include "crypto/test/hex.h"
 
+#include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 TEST_PREAMBLE("HMAC");

--- a/src/crypto/primitives/aes/test_aes_cbc.c
+++ b/src/crypto/primitives/aes/test_aes_cbc.c
@@ -21,6 +21,7 @@
 #include "crypto/test/hex.h"
 
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 TEST_PREAMBLE("AES-CBC");

--- a/src/crypto/primitives/sha1/test_sha1.c
+++ b/src/crypto/primitives/sha1/test_sha1.c
@@ -21,6 +21,7 @@
 #include "crypto/test/hex.h"
 
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 TEST_PREAMBLE("SHA1");

--- a/src/crypto/primitives/sha3/test_sha3.c
+++ b/src/crypto/primitives/sha3/test_sha3.c
@@ -21,6 +21,7 @@
 #include "crypto/test/hex.h"
 
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 TEST_PREAMBLE("SHA3");


### PR DESCRIPTION
A few `#include` directives were missing following the conversions of test vectors to hexadecimal byte strings (specifically, those conversions made in #16, #18, #20, and #21). This pull request adds the missing `#include` directives necessary for `free(3)` and the `size_t` type.