### PR TITLE
Fix comments in AES headers about buffer overlap

### DIFF
--- a/src/crypto/primitives/aes/aes_cbc.h
+++ b/src/crypto/primitives/aes/aes_cbc.h
@@ -72,9 +72,10 @@ void aes_cbc_set_iv(struct aes_cbc_ctx *ctx, const byte_t *iv);
  * stores the encrypted or decrypted block in the output. The initialization
  * vector will be updated with a new value, per the CBC algorithm.
  *
- * The two pointers, block and output, may overlap. The output of these
- * functions is undefined if both aes_cbc_set_key() and aes_cbc_set_iv() have
- * not been called.
+ * The two pointers, block and output, cannot overlap.
+ *
+ * The output of these functions is undefined if either of aes_cbc_set_key() or
+ * aes_cbc_set_iv() has not been called.
  */
 void aes_cbc_encrypt(struct aes_cbc_ctx *ctx, const byte_t *block,
                      byte_t *output);

--- a/src/crypto/primitives/aes/aes_ecb.h
+++ b/src/crypto/primitives/aes/aes_ecb.h
@@ -58,9 +58,12 @@ void aes_ecb_set_key(struct aes_ecb_ctx *ctx, const byte_t *key,
 
 /*
  * Encrypts or decrypts a single block of data using the given context and
- * stores the encrypted or decrypted block in the output. The two pointers,
- * block and output, may overlap. The output of these functions is undefined
- * if aes_ecb_set_key() has not been called.
+ * stores the encrypted or decrypted block in the output. The output of these
+ * functions is undefined if aes_ecb_set_key() has not been called.
+ *
+ * The two pointers, block and output, may overlap. However, it should be noted
+ * that in other AES cipher modes, the input and output buffers might not be
+ * allowed to overlap.
  */
 void aes_ecb_encrypt(struct aes_ecb_ctx *ctx, const byte_t *block,
                      byte_t *output);


### PR DESCRIPTION
A comment in the `aes_cbc.h` header file incorrectly stated that the input and output buffers may overlap. The error was strictly in the comment, because the input and output buffers for AES-CBC never actually overlapped anywhere in the Pisces codebase.