### PR TITLE
Improve conformity with C99 standard

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
+Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
+# Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -18,8 +18,8 @@ CC    = cc
 BUILD = release
 CPRNG = arc4random
 
-CFLAGS.BUILD.release    = -Wall -O2
-CFLAGS.BUILD.debug      = -Wall -DDEBUGGING -g
+CFLAGS.BUILD.release    = -Wall -pedantic -std=c99 -O2
+CFLAGS.BUILD.debug      = -Wall -pedantic -std=c99 -DDEBUGGING -g
 CFLAGS.CPRNG.arc4random =
 CFLAGS.CPRNG.dev        = -DPISCES_NO_ARC4RANDOM # Use /dev/random instead
 CFLAGS                  = ${CFLAGS.CPRNG.${CPRNG}}${CFLAGS.BUILD.${BUILD}}
@@ -27,6 +27,8 @@ CFLAGS                  = ${CFLAGS.CPRNG.${CPRNG}}${CFLAGS.BUILD.${BUILD}}
 IGNORE_FAILED_TESTS.BUILD.release =
 IGNORE_FAILED_TESTS.BUILD.debug   = -
 IGNORE_FAILED_TESTS               = ${IGNORE_FAILED_TESTS.BUILD.${BUILD}}
+
+LDFLAGS = ${CFLAGS}
 
 PREFIX         = /usr/local
 INSTALL_BIN    = ${PREFIX}/bin
@@ -88,7 +90,7 @@ generate: ${BINDIR}/generate_aes ${BINDIR}/generate_sha3
 GENERATE_AES_OBJS = src/crypto/primitives/aes/generate_aes.o
 
 ${BINDIR}/generate_aes: ${GENERATE_AES_OBJS}
-	${CC} ${CFLAGS} -o $@ ${GENERATE_AES_OBJS}
+	${CC} ${LDFLAGS} -o $@ ${GENERATE_AES_OBJS}
 
 ##
 # crypto/generate/generate_sha3
@@ -97,7 +99,7 @@ ${BINDIR}/generate_aes: ${GENERATE_AES_OBJS}
 GENERATE_SHA3_OBJS = src/crypto/primitives/sha3/generate_sha3.o
 
 ${BINDIR}/generate_sha3: ${GENERATE_SHA3_OBJS}
-	${CC} ${CFLAGS} -o $@ ${GENERATE_SHA3_OBJS}
+	${CC} ${LDFLAGS} -o $@ ${GENERATE_SHA3_OBJS}
 
 ##
 # Tests
@@ -114,7 +116,7 @@ TEST_AES_ECB_OBJS = src/crypto/primitives/aes/test_aes_ecb.o \
   src/crypto/primitives/aes/aes_ecb.o src/crypto/test/hex.o
 
 ${BINDIR}/test_aes_ecb: ${TEST_AES_ECB_OBJS}
-	${CC} ${CFLAGS} -o $@ ${TEST_AES_ECB_OBJS}
+	${CC} ${LDFLAGS} -o $@ ${TEST_AES_ECB_OBJS}
 	${IGNORE_FAILED_TESTS}@${BINDIR}/test_aes_ecb
 
 ##
@@ -126,7 +128,7 @@ TEST_AES_CBC_OBJS = src/crypto/primitives/aes/test_aes_cbc.o \
   src/crypto/test/hex.o
 
 ${BINDIR}/test_aes_cbc: ${TEST_AES_CBC_OBJS}
-	${CC} ${CFLAGS} -o $@ ${TEST_AES_CBC_OBJS}
+	${CC} ${LDFLAGS} -o $@ ${TEST_AES_CBC_OBJS}
 	${IGNORE_FAILED_TESTS}@${BINDIR}/test_aes_cbc
 
 ##
@@ -137,7 +139,7 @@ TEST_SHA1_OBJS = src/crypto/primitives/sha1/test_sha1.o \
   src/crypto/primitives/sha1/sha1.o src/crypto/test/hex.o
 
 ${BINDIR}/test_sha1: ${TEST_SHA1_OBJS}
-	${CC} ${CFLAGS} -o $@ ${TEST_SHA1_OBJS}
+	${CC} ${LDFLAGS} -o $@ ${TEST_SHA1_OBJS}
 	${IGNORE_FAILED_TESTS}@${BINDIR}/test_sha1
 
 ##
@@ -148,7 +150,7 @@ TEST_SHA3_OBJS = src/crypto/primitives/sha3/test_sha3.o \
   src/crypto/primitives/sha3/sha3.o src/crypto/test/hex.o
 
 ${BINDIR}/test_sha3: ${TEST_SHA3_OBJS}
-	${CC} ${CFLAGS} -o $@ ${TEST_SHA3_OBJS}
+	${CC} ${LDFLAGS} -o $@ ${TEST_SHA3_OBJS}
 	${IGNORE_FAILED_TESTS}@${BINDIR}/test_sha3
 
 ##
@@ -161,7 +163,7 @@ TEST_HMAC_OBJS = src/crypto/algorithms/hmac/test_hmac.o \
   src/crypto/test/hex.o
 
 ${BINDIR}/test_hmac: ${TEST_HMAC_OBJS}
-	${CC} ${CFLAGS} -o $@ ${TEST_HMAC_OBJS}
+	${CC} ${LDFLAGS} -o $@ ${TEST_HMAC_OBJS}
 	${IGNORE_FAILED_TESTS}@${BINDIR}/test_hmac
 
 ##
@@ -174,7 +176,7 @@ TEST_PBKDF2_OBJS = src/crypto/algorithms/pbkdf2/test_pbkdf2.o \
   src/crypto/primitives/sha3/sha3.o src/crypto/test/hex.o
 
 ${BINDIR}/test_pbkdf2: ${TEST_PBKDF2_OBJS}
-	${CC} ${CFLAGS} -o $@ ${TEST_PBKDF2_OBJS}
+	${CC} ${LDFLAGS} -o $@ ${TEST_PBKDF2_OBJS}
 	${IGNORE_FAILED_TESTS}@${BINDIR}/test_pbkdf2
 
 ##
@@ -191,7 +193,7 @@ PISCES_OBJS = src/crypto/abstract/cprng.o src/crypto/abstract/kdf.o \
   src/pisces/version.o src/pisces/encryption.o src/pisces/pisces.o
 
 ${BINDIR}/pisces: ${PISCES_OBJS}
-	${CC} ${CFLAGS} -o $@ ${PISCES_OBJS}
+	${CC} ${LDFLAGS} -o $@ ${PISCES_OBJS}
 
 ##
 # pwgen/
@@ -201,7 +203,7 @@ PWGEN_OBJS = src/pwgen/pwgen.o src/pwgen/ascii.o src/pwgen/hex.o \
   src/pwgen/usq.o src/crypto/abstract/cprng.o
 
 ${BINDIR}/pwgen: ${PWGEN_OBJS}
-	${CC} ${CFLAGS} -o $@ ${PWGEN_OBJS}
+	${CC} ${LDFLAGS} -o $@ ${PWGEN_OBJS}
 
 ##
 # Clean: remove all object files

--- a/src/common/errorflow.h
+++ b/src/common/errorflow.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -30,20 +30,20 @@
  * the output.
  */
 #ifdef DEBUGGING
-#define ERROR(target, flag, printfArgs...)                                    \
+#define ERROR(target, flag, ...)                                              \
     do {                                                                      \
         fprintf(ERROR_OUTPUT, "Error [%s:%d]: ", __FILE__, __LINE__);         \
-        fprintf(ERROR_OUTPUT, ##printfArgs);                                  \
+        fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
         fprintf(ERROR_OUTPUT, "\n");                                          \
         fflush(ERROR_OUTPUT);                                                 \
         flag = 1;                                                             \
         goto target;                                                          \
     } while (0)
 #else
-#define ERROR(target, flag, printfArgs...)                                    \
+#define ERROR(target, flag, ...)                                              \
     do {                                                                      \
         fprintf(ERROR_OUTPUT, "Error: ");                                     \
-        fprintf(ERROR_OUTPUT, ##printfArgs);                                  \
+        fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
         fprintf(ERROR_OUTPUT, "\n");                                          \
         fflush(ERROR_OUTPUT);                                                 \
         flag = 1;                                                             \
@@ -102,23 +102,23 @@
  * case.
  */
 #ifdef DEBUGGING
-#define ASSERT(condition, printfArgs...)                                      \
+#define ASSERT(condition, ...)                                                \
     do {                                                                      \
         if (!(condition)) {                                                   \
             fprintf(ERROR_OUTPUT, "Failed assertion [%s:%d]\n", __FILE__,     \
                     __LINE__);                                                \
-            fprintf(ERROR_OUTPUT, ##printfArgs);                              \
+            fprintf(ERROR_OUTPUT, __VA_ARGS__);                               \
             fprintf(ERROR_OUTPUT, "\n");                                      \
             fflush(ERROR_OUTPUT);                                             \
             abort();                                                          \
         }                                                                     \
     } while (0)
 #else
-#define ASSERT(condition, printfArgs...)                                      \
+#define ASSERT(condition, ...)                                                \
     do {                                                                      \
         if (!(condition)) {                                                   \
             fprintf(ERROR_OUTPUT, "Error: ");                                 \
-            fprintf(ERROR_OUTPUT, ##printfArgs);                              \
+            fprintf(ERROR_OUTPUT, __VA_ARGS__);                               \
             fprintf(ERROR_OUTPUT, "\n");                                      \
             fflush(ERROR_OUTPUT);                                             \
             abort();                                                          \
@@ -158,20 +158,20 @@
  * be aborted in either case.
  */
 #ifdef DEBUGGING
-#define FATAL_ERROR(printfArgs...)                                            \
+#define FATAL_ERROR(...)                                                      \
     do {                                                                      \
         fprintf(ERROR_OUTPUT, "Fatal error at [%s:%d]\n", __FILE__,           \
                 __LINE__);                                                    \
-        fprintf(ERROR_OUTPUT, ##printfArgs);                                  \
+        fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
         fprintf(ERROR_OUTPUT, "\n");                                          \
         fflush(ERROR_OUTPUT);                                                 \
         abort();                                                              \
     } while (0)
 #else
-#define FATAL_ERROR(printfArgs...)                                            \
+#define FATAL_ERROR(...)                                                      \
     do {                                                                      \
         fprintf(ERROR_OUTPUT, "Fatal error: ");                               \
-        fprintf(ERROR_OUTPUT, ##printfArgs);                                  \
+        fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
         fprintf(ERROR_OUTPUT, "\n");                                          \
         fflush(ERROR_OUTPUT);                                                 \
         abort();                                                              \

--- a/src/crypto/abstract/cprng.c
+++ b/src/crypto/abstract/cprng.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2011-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -79,7 +79,7 @@ static void cprng_bytes_arc4random(struct cprng *rng, byte_t *bytes,
 static void cprng_bytes_devrandom(struct cprng *rng, byte_t *bytes,
                                   size_t numBytes);
 
-struct cprng *cprng_alloc_default()
+struct cprng *cprng_alloc_default(void)
 {
     struct cprng *ret = (struct cprng *)calloc(1, sizeof(struct cprng));
     ASSERT_ALLOC(ret);

--- a/src/crypto/abstract/cprng.h
+++ b/src/crypto/abstract/cprng.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2011-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -32,7 +32,7 @@ struct cprng;
  * Guaranteed to return non-NULL; it is a fatal error for the allocation of the
  * PRNG to fail.
  */
-struct cprng *cprng_alloc_default();
+struct cprng *cprng_alloc_default(void);
 
 /*
  * Fills the given buffer with bytes from the pseudorandom number generator.

--- a/src/crypto/algorithms/hmac/test_hmac.c
+++ b/src/crypto/algorithms/hmac/test_hmac.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2023-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -355,7 +355,7 @@ static const struct hmac_test customTests[] = {
 /*
  * Run the HMAC tests and report the success rate.
  */
-int main()
+int main(void)
 {
     size_t onTest;
 

--- a/src/crypto/algorithms/pbkdf2/test_pbkdf2.c
+++ b/src/crypto/algorithms/pbkdf2/test_pbkdf2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2023-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -385,7 +385,7 @@ static const struct pbkdf2_test customTests[] = {
 /*
  * Run the PBKDF2 tests and report the success rate.
  */
-int main()
+int main(void)
 {
     size_t onTest;
 

--- a/src/crypto/primitives/aes/generate_aes.c
+++ b/src/crypto/primitives/aes/generate_aes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2011-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -85,7 +85,7 @@ static void build_sub_mix_table(const uint8_t *sbox,
 /*
  * Builds the round constant table and outputs it.
  */
-static void build_rcon_table();
+static void build_rcon_table(void);
 
 /*
  * Treats the two given bytes as a polynomials over GF(2^8) and multiplies them
@@ -117,7 +117,7 @@ void print_bytes(const uint8_t *bytes, size_t numBytes);
  * source file, provided that S_BOX_ENC is already defined.  The contents of
  * the encryption S-Box can be found in FIPS-197.
  */
-int main()
+int main(void)
 {
     uint8_t decSBox[256];
     build_dec_sbox(S_BOX_ENC, decSBox);
@@ -204,7 +204,7 @@ static void build_sub_mix_table(const uint8_t *sbox,
     print_table(table, 256, 4, 6, name, "uint32_t");
 }
 
-static void build_rcon_table()
+static void build_rcon_table(void)
 {
     uint8_t table[40];
     uint8_t poly = 0x01;

--- a/src/crypto/primitives/aes/test_aes_cbc.c
+++ b/src/crypto/primitives/aes/test_aes_cbc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2023-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -306,7 +306,7 @@ static const struct aes_cbc_monte_test monteTests[] = {
 /*
  * Run the AES-CBC tests and report the success rate.
  */
-int main()
+int main(void)
 {
     size_t onTest;
 

--- a/src/crypto/primitives/aes/test_aes_ecb.c
+++ b/src/crypto/primitives/aes/test_aes_ecb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2023-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -297,7 +297,7 @@ static const struct aes_ecb_monte_test monteTests[] = {
 /*
  * Run the AES-ECB tests and report the success rate.
  */
-int main()
+int main(void)
 {
     size_t onTest;
 

--- a/src/crypto/primitives/sha1/test_sha1.c
+++ b/src/crypto/primitives/sha1/test_sha1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2023-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -203,7 +203,7 @@ static const struct sha1_monte_test monteTests[] = {
 /*
  * Run the SHA-1 tests and report the success rate.
  */
-int main()
+int main(void)
 {
     size_t onTest;
 

--- a/src/crypto/primitives/sha3/generate_sha3.c
+++ b/src/crypto/primitives/sha3/generate_sha3.c
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2013-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2013-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -21,7 +21,7 @@
 /*
  * Generates and outputs the keccak_f function.
  */
-static void generate_keccak_f();
+static void generate_keccak_f(void);
 
 /*
  * Computes the rotation constant in the rho step for the given x, y pair.
@@ -49,13 +49,13 @@ static int two_dim_array(int x, int y);
  */
 static int mod(int x, int m);
 
-int main()
+int main(void)
 {
     generate_keccak_f();
     return 0;
 }
 
-static void generate_keccak_f()
+static void generate_keccak_f(void)
 {
     int round, x, y, rot, i;
     uint64_t rc;

--- a/src/crypto/primitives/sha3/test_sha3.c
+++ b/src/crypto/primitives/sha3/test_sha3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2023-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -370,7 +370,7 @@ static const struct sha3_monte_test monteTests[] = {
 /*
  * Run the SHA-3 tests and report the success rate.
  */
-int main()
+int main(void)
 {
     size_t onTest;
 

--- a/src/crypto/test/framework.h
+++ b/src/crypto/test/framework.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2023-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -34,7 +34,7 @@
 #define TEST_PREAMBLE(name)                                                   \
     static const char *TEST_NAME = (name);                                    \
     static int TEST_ASSERTIONS_FAILED = 0;                                    \
-    static int TEST_ASSERTIONS_TOTAL = 0;
+    static int TEST_ASSERTIONS_TOTAL = 0
 
 /*
  * If the given condition is not true, output the source location where it

--- a/src/pisces/pisces.c
+++ b/src/pisces/pisces.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -58,7 +58,7 @@ static int check_files(char *inputFile, char *outputFile);
  * Prints the usage message and version number to stderr and exit with a
  * negative code.
  */
-static void usage();
+static void usage(void);
 
 int main(int argc, char **argv)
 {
@@ -212,7 +212,7 @@ isErr:
     return errVal ? -1 : 0;
 }
 
-static void usage()
+static void usage(void)
 {
     fprintf(stderr,
             "usage: pisces [-de] [-p password] input_file output_file\n"

--- a/src/pisces/version.c
+++ b/src/pisces/version.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -40,12 +40,12 @@ isErr:
     return errVal ? -1 : 0;
 }
 
-int pisces_get_version()
+int pisces_get_version(void)
 {
     return piscesVersion;
 }
 
-struct cipher_ctx *pisces_unpadded_cipher_alloc()
+struct cipher_ctx *pisces_unpadded_cipher_alloc(void)
 {
     switch (piscesVersion) {
     case 3:
@@ -59,7 +59,7 @@ struct cipher_ctx *pisces_unpadded_cipher_alloc()
     }
 }
 
-struct cipher_ctx *pisces_padded_cipher_alloc()
+struct cipher_ctx *pisces_padded_cipher_alloc(void)
 {
     switch (piscesVersion) {
     case 3:
@@ -73,7 +73,7 @@ struct cipher_ctx *pisces_padded_cipher_alloc()
     }
 }
 
-struct chf_ctx *pisces_chf_alloc()
+struct chf_ctx *pisces_chf_alloc(void)
 {
     switch (piscesVersion) {
     case 3:
@@ -87,7 +87,7 @@ struct chf_ctx *pisces_chf_alloc()
     }
 }
 
-struct kdf *pisces_kdf_alloc()
+struct kdf *pisces_kdf_alloc(void)
 {
     switch (piscesVersion) {
     case 3:

--- a/src/pisces/version.h
+++ b/src/pisces/version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -37,26 +37,26 @@ int pisces_set_version(int version);
 /*
  * Gets the version of Pisces that is currently in use.
  */
-int pisces_get_version();
+int pisces_get_version(void);
 
 /*
  * Gets the cipher used by this version of Pisces to encrypt the header.
  */
-struct cipher_ctx *pisces_unpadded_cipher_alloc();
+struct cipher_ctx *pisces_unpadded_cipher_alloc(void);
 
 /*
  * Gets the cipher used by this version of Pisces to encrypt the file body.
  */
-struct cipher_ctx *pisces_padded_cipher_alloc();
+struct cipher_ctx *pisces_padded_cipher_alloc(void);
 
 /*
  * Gets the cryptographic hash function used by this version of Pisces.
  */
-struct chf_ctx *pisces_chf_alloc();
+struct chf_ctx *pisces_chf_alloc(void);
 
 /*
  * Gets the key derivation function used by this version of Pisces.
  */
-struct kdf *pisces_kdf_alloc();
+struct kdf *pisces_kdf_alloc(void);
 
 #endif

--- a/src/pwgen/pwgen.c
+++ b/src/pwgen/pwgen.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -61,7 +61,7 @@ static void set_length_value(size_t *length, char *theArg);
  * Prints the usage message and version number to stderr and exit with a
  * negative code.
  */
-static void usage();
+static void usage(void);
 
 int main(int argc, char **argv)
 {
@@ -181,7 +181,7 @@ isErr:
     }
 }
 
-static void usage()
+static void usage(void)
 {
     fprintf(stderr, "usage: pwgen [-aeHhns] [-l length]\n");
     fprintf(stderr, "pwgen version %s\n", IMPLEMENTATION_VERSION);


### PR DESCRIPTION
Remove named variable arguments from variadic macros, and add a `void` parameter list to functions that take no arguments. Additionally, to better adhere to conventions, change `CFLAGS` to `LDFLAGS` in the linker stage of the build.