### PR TITLE
Standardize error-flow macros

### DIFF
--- a/src/common/errorflow.h
+++ b/src/common/errorflow.h
@@ -174,4 +174,20 @@
         }                                                                     \
     } while (0)
 
+/*
+ * Asserts that a line of code should not be reached. If it is reached, this
+ * macro prints the given variable-argument message, along with the filename
+ * and line number. Then, it aborts the program.
+ */
+#define ASSERT_NEVER_REACH(...)                                               \
+    do {                                                                      \
+        fprintf(ERROR_OUTPUT,                                                 \
+                "Failed assertion [%s:%d, never reach]: ", __FILE__,          \
+                __LINE__);                                                    \
+        fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
+        fprintf(ERROR_OUTPUT, "\n");                                          \
+        fflush(ERROR_OUTPUT);                                                 \
+        abort();                                                              \
+    } while (0)
+
 #endif

--- a/src/common/errorflow.h
+++ b/src/common/errorflow.h
@@ -139,7 +139,7 @@
             fprintf(ERROR_OUTPUT, "Memory allocation failed [%s:%d]\n",       \
                     __FILE__, __LINE__);                                      \
             fflush(ERROR_OUTPUT);                                             \
-            abort();                                                          \
+            exit(EXIT_FAILURE);                                               \
         }                                                                     \
     } while (0)
 #else
@@ -147,7 +147,7 @@
     do {                                                                      \
         if ((ptr) == NULL) {                                                  \
             fprintf(ERROR_OUTPUT, "Memory allocation failed\n");              \
-            abort();                                                          \
+            exit(EXIT_FAILURE);                                               \
         }                                                                     \
     } while (0)
 #endif
@@ -165,7 +165,7 @@
         fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
         fprintf(ERROR_OUTPUT, "\n");                                          \
         fflush(ERROR_OUTPUT);                                                 \
-        abort();                                                              \
+        exit(EXIT_FAILURE);                                                   \
     } while (0)
 #else
 #define FATAL_ERROR(...)                                                      \
@@ -174,7 +174,7 @@
         fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
         fprintf(ERROR_OUTPUT, "\n");                                          \
         fflush(ERROR_OUTPUT);                                                 \
-        abort();                                                              \
+        exit(EXIT_FAILURE);                                                   \
     } while (0)
 #endif
 

--- a/src/common/errorflow.h
+++ b/src/common/errorflow.h
@@ -25,7 +25,7 @@
 #endif
 
 /*
- * Print the given message, set the error flag to 1, and jump to the specified
+ * Print the given message, set the error flag to -1, and jump to the specified
  * target. If DEBUGGING is defined, also include the file and line number in
  * the output.
  */
@@ -36,7 +36,7 @@
         fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
         fprintf(ERROR_OUTPUT, "\n");                                          \
         fflush(ERROR_OUTPUT);                                                 \
-        flag = 1;                                                             \
+        flag = -1;                                                            \
         goto target;                                                          \
     } while (0)
 #else
@@ -46,7 +46,7 @@
         fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
         fprintf(ERROR_OUTPUT, "\n");                                          \
         fflush(ERROR_OUTPUT);                                                 \
-        flag = 1;                                                             \
+        flag = -1;                                                            \
         goto target;                                                          \
     } while (0)
 #endif
@@ -74,7 +74,7 @@
 #endif
 
 /*
- * Set the error flag to 1, and jump to the specified target. If DEBUGGING is
+ * Set the error flag to -1, and jump to the specified target. If DEBUGGING is
  * defined, print a message with the file and line number (otherwise print
  * nothing). Functionally equivalent to ERROR_CODE(target, flag, 1), though the
  * message printed is slightly different.
@@ -84,13 +84,13 @@
     do {                                                                      \
         fprintf(ERROR_OUTPUT, "Quiet error [%s:%d]\n", __FILE__, __LINE__);   \
         fflush(ERROR_OUTPUT);                                                 \
-        flag = 1;                                                             \
+        flag = -1;                                                            \
         goto target;                                                          \
     } while (0)
 #else
 #define ERROR_QUIET(target, flag)                                             \
     do {                                                                      \
-        flag = 1;                                                             \
+        flag = -1;                                                            \
         goto target;                                                          \
     } while (0)
 #endif

--- a/src/common/errorflow.h
+++ b/src/common/errorflow.h
@@ -133,7 +133,7 @@
  * checked in either case.
  */
 #ifdef DEBUGGING
-#define ASSERT_ALLOC(ptr)                                                     \
+#define GUARD_ALLOC(ptr)                                                      \
     do {                                                                      \
         if ((ptr) == NULL) {                                                  \
             fprintf(ERROR_OUTPUT, "Memory allocation failed [%s:%d]\n",       \
@@ -143,7 +143,7 @@
         }                                                                     \
     } while (0)
 #else
-#define ASSERT_ALLOC(ptr)                                                     \
+#define GUARD_ALLOC(ptr)                                                      \
     do {                                                                      \
         if ((ptr) == NULL) {                                                  \
             fprintf(ERROR_OUTPUT, "Memory allocation failed\n");              \

--- a/src/common/errorflow.h
+++ b/src/common/errorflow.h
@@ -25,149 +25,88 @@
 #endif
 
 /*
- * Print the given message, set the error flag to -1, and jump to the specified
- * target. If DEBUGGING is defined, also include the file and line number in
- * the output.
+ * Prints the given variable-argument message, sets the int-type flag variable
+ * to -1, and jumps to the specified target.
+ *
+ * If DEBUGGING is defined, the filename and line number are included the
+ * output.
  */
-#ifdef DEBUGGING
+#ifndef DEBUGGING
 #define ERROR(target, flag, ...)                                              \
     do {                                                                      \
-        fprintf(ERROR_OUTPUT, "Error [%s:%d]: ", __FILE__, __LINE__);         \
-        fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
-        fprintf(ERROR_OUTPUT, "\n");                                          \
-        fflush(ERROR_OUTPUT);                                                 \
         flag = -1;                                                            \
-        goto target;                                                          \
-    } while (0)
-#else
-#define ERROR(target, flag, ...)                                              \
-    do {                                                                      \
         fprintf(ERROR_OUTPUT, "Error: ");                                     \
         fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
         fprintf(ERROR_OUTPUT, "\n");                                          \
         fflush(ERROR_OUTPUT);                                                 \
-        flag = -1;                                                            \
-        goto target;                                                          \
-    } while (0)
-#endif
-
-/*
- * Set the error flag to the given integer value, and jump to the specified
- * target. If DEBUGGING is defined, print a message with the file and line
- * number (otherwise, print nothing).
- */
-#ifdef DEBUGGING
-#define ERROR_CODE(target, flag, flagValue)                                   \
-    do {                                                                      \
-        fprintf(ERROR_OUTPUT, "Error code %d [%s:%d]\n", flagValue, __FILE__, \
-                __LINE__);                                                    \
-        fflush(ERROR_OUTPUT);                                                 \
-        flag = (flagValue);                                                   \
         goto target;                                                          \
     } while (0)
 #else
-#define ERROR_CODE(target, flag, flagValue)                                   \
-    do {                                                                      \
-        flag = (flagValue);                                                   \
-        goto target;                                                          \
-    } while (0)
-#endif
-
-/*
- * Set the error flag to -1, and jump to the specified target. If DEBUGGING is
- * defined, print a message with the file and line number (otherwise print
- * nothing). Functionally equivalent to ERROR_CODE(target, flag, 1), though the
- * message printed is slightly different.
- */
-#ifdef DEBUGGING
-#define ERROR_QUIET(target, flag)                                             \
-    do {                                                                      \
-        fprintf(ERROR_OUTPUT, "Quiet error [%s:%d]\n", __FILE__, __LINE__);   \
-        fflush(ERROR_OUTPUT);                                                 \
-        flag = -1;                                                            \
-        goto target;                                                          \
-    } while (0)
-#else
-#define ERROR_QUIET(target, flag)                                             \
+#define ERROR(target, flag, ...)                                              \
     do {                                                                      \
         flag = -1;                                                            \
-        goto target;                                                          \
-    } while (0)
-#endif
-
-/*
- * Assert that the given condition is true. Otherwise, print the given error
- * message and abort the program. If DEBUGGING is defined, additional
- * information will be printed; however, the assertion is checked in either
- * case.
- */
-#ifdef DEBUGGING
-#define ASSERT(condition, ...)                                                \
-    do {                                                                      \
-        if (!(condition)) {                                                   \
-            fprintf(ERROR_OUTPUT, "Failed assertion [%s:%d]\n", __FILE__,     \
-                    __LINE__);                                                \
-            fprintf(ERROR_OUTPUT, __VA_ARGS__);                               \
-            fprintf(ERROR_OUTPUT, "\n");                                      \
-            fflush(ERROR_OUTPUT);                                             \
-            abort();                                                          \
-        }                                                                     \
-    } while (0)
-#else
-#define ASSERT(condition, ...)                                                \
-    do {                                                                      \
-        if (!(condition)) {                                                   \
-            fprintf(ERROR_OUTPUT, "Error: ");                                 \
-            fprintf(ERROR_OUTPUT, __VA_ARGS__);                               \
-            fprintf(ERROR_OUTPUT, "\n");                                      \
-            fflush(ERROR_OUTPUT);                                             \
-            abort();                                                          \
-        }                                                                     \
-    } while (0)
-#endif
-
-/*
- * Assert that the return from an allocation call, such as malloc() or calloc()
- * is non-NULL. If not, print an error message and abort. If DEBUGGING is
- * defined, additional information will be printed; however, the pointer is
- * checked in either case.
- */
-#ifdef DEBUGGING
-#define GUARD_ALLOC(ptr)                                                      \
-    do {                                                                      \
-        if ((ptr) == NULL) {                                                  \
-            fprintf(ERROR_OUTPUT, "Memory allocation failed [%s:%d]\n",       \
-                    __FILE__, __LINE__);                                      \
-            fflush(ERROR_OUTPUT);                                             \
-            exit(EXIT_FAILURE);                                               \
-        }                                                                     \
-    } while (0)
-#else
-#define GUARD_ALLOC(ptr)                                                      \
-    do {                                                                      \
-        if ((ptr) == NULL) {                                                  \
-            fprintf(ERROR_OUTPUT, "Memory allocation failed\n");              \
-            exit(EXIT_FAILURE);                                               \
-        }                                                                     \
-    } while (0)
-#endif
-
-/*
- * Print the given error message and abort the program. If DEBUGGING is
- * defined, additional information will be printed; however, the program will
- * be aborted in either case.
- */
-#ifdef DEBUGGING
-#define FATAL_ERROR(...)                                                      \
-    do {                                                                      \
-        fprintf(ERROR_OUTPUT, "Fatal error at [%s:%d]\n", __FILE__,           \
-                __LINE__);                                                    \
+        fprintf(ERROR_OUTPUT, "Error [%s:%d]: ", __FILE__, __LINE__);         \
         fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
         fprintf(ERROR_OUTPUT, "\n");                                          \
         fflush(ERROR_OUTPUT);                                                 \
-        exit(EXIT_FAILURE);                                                   \
+        goto target;                                                          \
+    } while (0)
+#endif
+
+/*
+ * Sets the int-type flag variable to -1, and jumps to the specified target.
+ *
+ * If DEBUGGING is defined, this macro also outputs a message with the
+ * filename and line number.
+ */
+#ifndef DEBUGGING
+#define ERROR_QUIET(target, flag)                                             \
+    do {                                                                      \
+        flag = -1;                                                            \
+        goto target;                                                          \
     } while (0)
 #else
+#define ERROR_QUIET(target, flag)                                             \
+    do {                                                                      \
+        flag = -1;                                                            \
+        fprintf(ERROR_OUTPUT, "Error [%s:%d, quiet]\n", __FILE__, __LINE__);  \
+        fflush(ERROR_OUTPUT);                                                 \
+        goto target;                                                          \
+    } while (0)
+#endif
+
+/*
+ * Sets the int-type flag variable to the given error code, and jumps to the
+ * specified target.
+ *
+ * If DEBUGGING is defined, this macro also outputs a message with the
+ * filename, line number, and error code.
+ */
+#ifndef DEBUGGING
+#define ERROR_CODE(target, flag, code)                                        \
+    do {                                                                      \
+        flag = (code);                                                        \
+        goto target;                                                          \
+    } while (0)
+#else
+#define ERROR_CODE(target, flag, code)                                        \
+    do {                                                                      \
+        flag = (code);                                                        \
+        fprintf(ERROR_OUTPUT, "Error [%s:%d, code %d]\n", __FILE__, __LINE__, \
+                flag);                                                        \
+        fflush(ERROR_OUTPUT);                                                 \
+        goto target;                                                          \
+    } while (0)
+#endif
+
+/*
+ * Prints the given variable-argument message, and exits the program with a
+ * failure code.
+ *
+ * If DEBUGGING is defined, the filename and line number are included in the
+ * output.
+ */
+#ifndef DEBUGGING
 #define FATAL_ERROR(...)                                                      \
     do {                                                                      \
         fprintf(ERROR_OUTPUT, "Fatal error: ");                               \
@@ -176,6 +115,63 @@
         fflush(ERROR_OUTPUT);                                                 \
         exit(EXIT_FAILURE);                                                   \
     } while (0)
+#else
+#define FATAL_ERROR(...)                                                      \
+    do {                                                                      \
+        fprintf(ERROR_OUTPUT, "Fatal error [%s:%d]: ", __FILE__, __LINE__);   \
+        fprintf(ERROR_OUTPUT, __VA_ARGS__);                                   \
+        fprintf(ERROR_OUTPUT, "\n");                                          \
+        fflush(ERROR_OUTPUT);                                                 \
+        exit(EXIT_FAILURE);                                                   \
+    } while (0)
 #endif
+
+/*
+ * Verifies that the given return from an allocation call, such as malloc() or
+ * calloc(), is non-NULL. If not, this macro prints an error message and exits
+ * the program with a failure code.
+ *
+ * If DEBUGGING is defined, the filename and line number are included in the
+ * output.
+ */
+#ifndef DEBUGGING
+#define GUARD_ALLOC(ptr)                                                      \
+    do {                                                                      \
+        if ((ptr) == NULL) {                                                  \
+            fprintf(ERROR_OUTPUT,                                             \
+                    "Fatal error: Memory allocation failure\n");              \
+            fflush(ERROR_OUTPUT);                                             \
+            exit(EXIT_FAILURE);                                               \
+        }                                                                     \
+    } while (0)
+#else
+#define GUARD_ALLOC(ptr)                                                      \
+    do {                                                                      \
+        if ((ptr) == NULL) {                                                  \
+            fprintf(ERROR_OUTPUT,                                             \
+                    "Fatal error [%s:%d]: Memory allocation failure\n",       \
+                    __FILE__, __LINE__);                                      \
+            fflush(ERROR_OUTPUT);                                             \
+            exit(EXIT_FAILURE);                                               \
+        }                                                                     \
+    } while (0)
+#endif
+
+/*
+ * Asserts that the given condition is true. If not, this macro prints the
+ * given variable-argument message, along with the filename, line number, and
+ * condition that failed. Then, it aborts the program.
+ */
+#define ASSERT(condition, ...)                                                \
+    do {                                                                      \
+        if (!(condition)) {                                                   \
+            fprintf(ERROR_OUTPUT, "Failed assertion [%s:%d, %s]: ", __FILE__, \
+                    __LINE__, #condition);                                    \
+            fprintf(ERROR_OUTPUT, __VA_ARGS__);                               \
+            fprintf(ERROR_OUTPUT, "\n");                                      \
+            fflush(ERROR_OUTPUT);                                             \
+            abort();                                                          \
+        }                                                                     \
+    } while (0)
 
 #endif

--- a/src/crypto/abstract/chf.c
+++ b/src/crypto/abstract/chf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -50,7 +50,7 @@ static inline void chf_ctx_free_scrub(struct chf_ctx *chf);
 struct chf_ctx *chf_alloc(chf_algorithm_t alg)
 {
     struct chf_ctx *ret = (struct chf_ctx *)calloc(1, sizeof(struct chf_ctx));
-    ASSERT_ALLOC(ret);
+    GUARD_ALLOC(ret);
 
     switch (alg) {
     case CHF_ALG_SHA1:

--- a/src/crypto/abstract/chf.c
+++ b/src/crypto/abstract/chf.c
@@ -62,7 +62,7 @@ struct chf_ctx *chf_alloc(chf_algorithm_t alg)
         ret->blockBytes = SHA3_512_BLOCK_BYTES;
         break;
     default:
-        FATAL_ERROR("Invalid CHF algorithm");
+        ASSERT_NEVER_REACH("Invalid CHF algorithm");
     }
 
     ret->type = alg;
@@ -152,7 +152,7 @@ const char *chf_error(const struct chf_ctx *chf)
     case CHF_ERROR_MESSAGE_TOO_LONG:
         return "Message length exceeded CHF maximum";
     default:
-        FATAL_ERROR("Invalid CHF error code");
+        ASSERT_NEVER_REACH("Invalid CHF error code");
     }
 }
 
@@ -175,7 +175,7 @@ static inline void chf_ctx_alloc(struct chf_ctx *chf)
         chf->ctx = sha3_alloc();
         break;
     default:
-        FATAL_ERROR("Invalid CHF algorithm");
+        ASSERT_NEVER_REACH("Invalid CHF algorithm");
     }
 }
 
@@ -189,7 +189,7 @@ static inline void chf_ctx_start(struct chf_ctx *chf)
         sha3_512_start((struct sha3_ctx *)chf->ctx);
         break;
     default:
-        FATAL_ERROR("Invalid CHF algorithm");
+        ASSERT_NEVER_REACH("Invalid CHF algorithm");
     }
 }
 
@@ -203,7 +203,7 @@ static inline int chf_ctx_add(struct chf_ctx *chf, const byte_t *bytes,
         sha3_add((struct sha3_ctx *)chf->ctx, bytes, numBytes);
         return 0;
     default:
-        FATAL_ERROR("Invalid CHF algorithm");
+        ASSERT_NEVER_REACH("Invalid CHF algorithm");
     }
 }
 
@@ -216,7 +216,7 @@ static inline int chf_ctx_end(struct chf_ctx *chf, byte_t *digest)
         sha3_end((struct sha3_ctx *)chf->ctx, digest);
         return 0;
     default:
-        FATAL_ERROR("Invalid CHF algorithm");
+        ASSERT_NEVER_REACH("Invalid CHF algorithm");
     }
 }
 
@@ -233,7 +233,7 @@ static inline void chf_ctx_copy(struct chf_ctx *dst, const struct chf_ctx *src)
                   (const struct sha3_ctx *)src->ctx);
         break;
     default:
-        FATAL_ERROR("Invalid CHF algorithm");
+        ASSERT_NEVER_REACH("Invalid CHF algorithm");
     }
 }
 
@@ -251,7 +251,7 @@ static inline void chf_ctx_free_scrub(struct chf_ctx *chf)
         sha3_free_scrub((struct sha3_ctx *)chf->ctx);
         break;
     default:
-        FATAL_ERROR("Invalid CHF algorithm");
+        ASSERT_NEVER_REACH("Invalid CHF algorithm");
     }
     chf->ctx = NULL;
 }

--- a/src/crypto/abstract/cipher.c
+++ b/src/crypto/abstract/cipher.c
@@ -77,7 +77,7 @@ struct cipher_ctx *cipher_alloc(cipher_algorithm_t alg)
         ret->algPadded = 1;
         break;
     default:
-        FATAL_ERROR("Invalid cipher algorithm");
+        ASSERT_NEVER_REACH("Invalid cipher algorithm");
     }
 
     ret->ctx = aes_cbc_alloc();
@@ -270,7 +270,7 @@ const char *cipher_error(const struct cipher_ctx *cipher)
     case CIPHER_ERROR_NO_BLOCK_TO_DEPAD:
         return "Cipher lacks input block to de-pad";
     default:
-        FATAL_ERROR("Invalid cipher error code");
+        ASSERT_NEVER_REACH("Invalid cipher error code");
     }
 }
 

--- a/src/crypto/abstract/cipher.c
+++ b/src/crypto/abstract/cipher.c
@@ -59,7 +59,7 @@ static size_t process_block(struct cipher_ctx *cipher, const byte_t *block,
 struct cipher_ctx *cipher_alloc(cipher_algorithm_t alg)
 {
     struct cipher_ctx *ret = calloc(1, sizeof(struct cipher_ctx));
-    ASSERT_ALLOC(ret);
+    GUARD_ALLOC(ret);
 
     switch (alg) {
     case CIPHER_ALG_AES_128_CBC_NOPAD:

--- a/src/crypto/abstract/cprng.c
+++ b/src/crypto/abstract/cprng.c
@@ -108,7 +108,7 @@ void cprng_bytes(struct cprng *rng, byte_t *bytes, size_t numBytes)
         cprng_bytes_devrandom(rng, bytes, numBytes);
         break;
     default:
-        FATAL_ERROR("Invalid CPRNG algorithm");
+        ASSERT_NEVER_REACH("Invalid CPRNG algorithm");
     }
 }
 
@@ -130,7 +130,7 @@ static void cprng_bytes_arc4random(struct cprng *rng, byte_t *bytes,
     UNUSED(rng);
     UNUSED(bytes);
     UNUSED(numBytes);
-    FATAL_ERROR("Not compiled with arc4random_buf() support");
+    ASSERT_NEVER_REACH("Not compiled with arc4random_buf() support");
 #else
     UNUSED(rng);
     arc4random_buf(bytes, numBytes);

--- a/src/crypto/abstract/cprng.c
+++ b/src/crypto/abstract/cprng.c
@@ -83,7 +83,7 @@ static void cprng_bytes_devrandom(struct cprng *rng, byte_t *bytes,
 struct cprng *cprng_alloc_default(void)
 {
     struct cprng *ret = (struct cprng *)calloc(1, sizeof(struct cprng));
-    ASSERT_ALLOC(ret);
+    GUARD_ALLOC(ret);
 
     if (PISCES_NO_ARC4RANDOM) {
         ret->type = CPRNG_ALG_DEVRANDOM;

--- a/src/crypto/abstract/kdf.c
+++ b/src/crypto/abstract/kdf.c
@@ -50,7 +50,7 @@ struct kdf *kdf_alloc(kdf_algorithm_t alg)
         ret->chfAlg = CHF_ALG_SHA1;
         break;
     default:
-        FATAL_ERROR("Invalid KDF algorithm");
+        ASSERT_NEVER_REACH("Invalid KDF algorithm");
     }
 
     return ret;
@@ -79,7 +79,7 @@ int kdf_derive(struct kdf *fn, byte_t *derivedKey, size_t derivedKeyLen,
         ret = KDF_ERROR_SALT_TOO_LONG;
         break;
     default:
-        FATAL_ERROR("Unknown PBKDF2 error return");
+        ASSERT_NEVER_REACH("Unknown PBKDF2 error return");
     }
 
     fn->errorCode = ret;
@@ -98,7 +98,7 @@ const char *kdf_error(const struct kdf *fn)
     case KDF_ERROR_SALT_TOO_LONG:
         return "KDF salt too long";
     default:
-        FATAL_ERROR("Invalid KDF error code");
+        ASSERT_NEVER_REACH("Invalid KDF error code");
     }
 }
 

--- a/src/crypto/abstract/kdf.c
+++ b/src/crypto/abstract/kdf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -34,7 +34,7 @@ struct kdf {
 struct kdf *kdf_alloc(kdf_algorithm_t alg)
 {
     struct kdf *ret = (struct kdf *)calloc(1, sizeof(struct kdf));
-    ASSERT_ALLOC(ret);
+    GUARD_ALLOC(ret);
 
     switch (alg) {
     case KDF_ALG_PBKDF2_HMAC_SHA3_512_16384:

--- a/src/crypto/algorithms/hmac/hmac.c
+++ b/src/crypto/algorithms/hmac/hmac.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2011-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -44,7 +44,7 @@ struct hmac_ctx *hmac_alloc(chf_algorithm_t alg)
 {
     struct hmac_ctx *ret =
         (struct hmac_ctx *)calloc(1, sizeof(struct hmac_ctx));
-    ASSERT_ALLOC(ret);
+    GUARD_ALLOC(ret);
 
     ret->innerCtx = chf_alloc(alg);
     ret->outerCtx = chf_alloc(alg);

--- a/src/crypto/algorithms/pbkdf2/test_pbkdf2.c
+++ b/src/crypto/algorithms/pbkdf2/test_pbkdf2.c
@@ -430,7 +430,7 @@ static void run_parsed_pbkdf2_test(chf_algorithm_t hashAlg,
 {
     byte_t *actual;
     actual = calloc(1, derivedKeyLen);
-    ASSERT_ALLOC(actual);
+    GUARD_ALLOC(actual);
 
     pbkdf2_hmac(actual, derivedKeyLen, (const char *)password, passwordLen,
                 salt, saltLen, iterationCount, hashAlg);

--- a/src/crypto/primitives/aes/aes_cbc.c
+++ b/src/crypto/primitives/aes/aes_cbc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -34,7 +34,7 @@ struct aes_cbc_ctx *aes_cbc_alloc(void)
 {
     struct aes_cbc_ctx *ret =
         (struct aes_cbc_ctx *)calloc(1, sizeof(struct aes_cbc_ctx));
-    ASSERT_ALLOC(ret);
+    GUARD_ALLOC(ret);
     ret->ecbCtx = aes_ecb_alloc();
     return ret;
 }

--- a/src/crypto/primitives/aes/aes_cbc.c
+++ b/src/crypto/primitives/aes/aes_cbc.c
@@ -53,7 +53,7 @@ void aes_cbc_set_key(struct aes_cbc_ctx *ctx, const byte_t *key,
         aes_ecb_set_key(ctx->ecbCtx, key, AES_ECB_KEY_SIZE_256);
         break;
     default:
-        FATAL_ERROR("Invalid AES-CBC key size");
+        ASSERT_NEVER_REACH("Invalid AES-CBC key size");
     }
 }
 

--- a/src/crypto/primitives/aes/aes_ecb.c
+++ b/src/crypto/primitives/aes/aes_ecb.c
@@ -736,7 +736,7 @@ void aes_ecb_set_key(struct aes_ecb_ctx *ctx, const byte_t *key,
         nk = 8;
         break;
     default:
-        FATAL_ERROR("Invalid AES-ECB key size");
+        ASSERT_NEVER_REACH("Invalid AES-ECB key size");
     }
 
     /* The first words in the key expansion are equal to the key itself */

--- a/src/crypto/primitives/aes/aes_ecb.c
+++ b/src/crypto/primitives/aes/aes_ecb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2011-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -711,7 +711,7 @@ struct aes_ecb_ctx *aes_ecb_alloc(void)
 {
     struct aes_ecb_ctx *ret =
         (struct aes_ecb_ctx *)calloc(1, sizeof(struct aes_ecb_ctx));
-    ASSERT_ALLOC(ret);
+    GUARD_ALLOC(ret);
     return ret;
 }
 

--- a/src/crypto/primitives/aes/test_aes_cbc.c
+++ b/src/crypto/primitives/aes/test_aes_cbc.c
@@ -360,7 +360,7 @@ static void run_parsed_aes_cbc_plain_test(const byte_t *key, size_t keySize,
     ctx = aes_cbc_alloc();
     textLen = numBlocks * AES_CBC_BLOCK_SIZE;
     actual = (byte_t *)calloc(textLen, 1);
-    ASSERT_ALLOC(actual);
+    GUARD_ALLOC(actual);
 
     aes_cbc_set_key(ctx, key, keySize);
     aes_cbc_multi_block(ctx, plaintext, iv, actual, numBlocks,

--- a/src/crypto/primitives/aes/test_aes_ecb.c
+++ b/src/crypto/primitives/aes/test_aes_ecb.c
@@ -349,7 +349,7 @@ static void run_parsed_aes_ecb_plain_test(const byte_t *key, size_t keySize,
     ctx = aes_ecb_alloc();
     textLen = numBlocks * AES_ECB_BLOCK_SIZE;
     actual = (byte_t *)calloc(textLen, 1);
-    ASSERT_ALLOC(actual);
+    GUARD_ALLOC(actual);
 
     aes_ecb_set_key(ctx, key, keySize);
     aes_ecb_multi_block(ctx, plaintext, actual, numBlocks,

--- a/src/crypto/primitives/sha1/sha1.c
+++ b/src/crypto/primitives/sha1/sha1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2011-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -63,7 +63,7 @@ struct sha1_ctx *sha1_alloc(void)
 {
     struct sha1_ctx *ret =
         (struct sha1_ctx *)calloc(1, sizeof(struct sha1_ctx));
-    ASSERT_ALLOC(ret);
+    GUARD_ALLOC(ret);
     return ret;
 }
 

--- a/src/crypto/primitives/sha3/sha3.c
+++ b/src/crypto/primitives/sha3/sha3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2013-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -44,7 +44,7 @@ struct sha3_ctx *sha3_alloc(void)
 {
     struct sha3_ctx *ret =
         (struct sha3_ctx *)calloc(1, sizeof(struct sha3_ctx));
-    ASSERT_ALLOC(ret);
+    GUARD_ALLOC(ret);
     return ret;
 }
 

--- a/src/crypto/primitives/sha3/test_sha3.c
+++ b/src/crypto/primitives/sha3/test_sha3.c
@@ -524,7 +524,7 @@ static void start_ctx(struct sha3_ctx *ctx, size_t digestLen)
         sha3_512_start(ctx);
         break;
     default:
-        FATAL_ERROR("Invalid SHA-3 digest size");
+        ASSERT_NEVER_REACH("Invalid SHA-3 digest size");
     }
 }
 
@@ -540,6 +540,6 @@ static size_t block_bytes(size_t digestLen)
     case SHA3_512_DIGEST_BYTES:
         return SHA3_512_BLOCK_BYTES;
     default:
-        FATAL_ERROR("Invalid SHA-3 digest size");
+        ASSERT_NEVER_REACH("Invalid SHA-3 digest size");
     }
 }

--- a/src/crypto/test/hex.c
+++ b/src/crypto/test/hex.c
@@ -34,6 +34,7 @@ void hex_to_bytes(const char *hex, byte_t **bytes, size_t *numBytes)
     size_t outLen;
     byte_t *out;
     unsigned int byteVal;
+    int scanRes;
 
     outLen = hex_byte_len(hex);
     out = (byte_t *)calloc(outLen, 1);
@@ -43,9 +44,8 @@ void hex_to_bytes(const char *hex, byte_t **bytes, size_t *numBytes)
     *bytes = out;
 
     while (outLen > 0) {
-        if (sscanf(hex, "%2x", &byteVal) != 1) {
-            FATAL_ERROR("Invalid value in hexadecimal string");
-        }
+        scanRes = sscanf(hex, "%2x", &byteVal);
+        ASSERT(scanRes == 1, "Invalid value in hexadecimal string");
         *out++ = (byte_t)byteVal;
         hex += 2;
         outLen--;

--- a/src/crypto/test/hex.c
+++ b/src/crypto/test/hex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2024-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -37,7 +37,7 @@ void hex_to_bytes(const char *hex, byte_t **bytes, size_t *numBytes)
 
     outLen = hex_byte_len(hex);
     out = (byte_t *)calloc(outLen, 1);
-    ASSERT_ALLOC(out);
+    GUARD_ALLOC(out);
 
     *numBytes = outLen;
     *bytes = out;

--- a/src/pisces/encryption.c
+++ b/src/pisces/encryption.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2024 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -218,7 +218,7 @@ isErr:
     }
     cprng_free_scrub(rng);
     scrub_memory(key, CIPHER_MAX_KEY_BYTES);
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 int decrypt_file(const char *inputFile, const char *outputFile,
@@ -273,7 +273,7 @@ isErr:
         close(out);
     }
     scrub_memory(key, CIPHER_MAX_KEY_BYTES);
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static int write_header(int fd, byte_t *salt, byte_t *imprintIV,
@@ -313,7 +313,7 @@ static int write_header(int fd, byte_t *salt, byte_t *imprintIV,
 
 isErr:
     cipher_free_scrub(cipher);
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static int read_header(int fd, byte_t *salt, byte_t *imprintIV, byte_t *bodyIV)
@@ -357,7 +357,7 @@ static int read_header(int fd, byte_t *salt, byte_t *imprintIV, byte_t *bodyIV)
 
 isErr:
     cipher_free_scrub(cipher);
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static int write_imprint(int fd, const byte_t *key, const byte_t *imprintIV,
@@ -408,7 +408,7 @@ isErr:
     cipher_free_scrub(cipher);
     scrub_memory(randomData, PISCES_MAX_RANDOM_SIZE);
     scrub_memory(randomHash, CHF_MAX_DIGEST_BYTES);
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static int read_imprint(int fd, const byte_t *key, const byte_t *imprintIV)
@@ -459,7 +459,7 @@ isErr:
     cipher_free_scrub(cipher);
     scrub_memory(decryptedImprint, PISCES_MAX_IMPRINT_SIZE);
     scrub_memory(computedHash, CHF_MAX_DIGEST_BYTES);
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static int encrypt_body(int in, int out, const byte_t *key,
@@ -531,7 +531,7 @@ isErr:
     cipher_free_scrub(cipher);
     scrub_memory(buffer, BYTES_AT_ONCE);
     scrub_memory(hash, CHF_MAX_DIGEST_BYTES);
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static int decrypt_body(int in, int out, const byte_t *key,
@@ -623,7 +623,7 @@ isErr:
     scrub_memory(retFromHB, BYTES_AT_ONCE + CIPHER_MAX_BLOCK_BYTES);
     scrub_memory(storedHash, CHF_MAX_DIGEST_BYTES);
     scrub_memory(computedHash, CHF_MAX_DIGEST_BYTES);
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static void generate_distinct_ivs(byte_t *ivA, byte_t *ivB, size_t ivLen,
@@ -664,7 +664,7 @@ static int password_to_key(byte_t *derivedKey, const char *password,
 isErr:
     cipher_free_scrub(cipher);
     kdf_free_scrub(fn);
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static void compute_imprint_sizes(size_t *randomData, size_t *total,

--- a/src/pisces/encryption.c
+++ b/src/pisces/encryption.c
@@ -639,7 +639,7 @@ static void generate_distinct_ivs(byte_t *ivA, byte_t *ivB, size_t ivLen,
      *
      * If they're identical twice in a row, terminate the program with a fatal
      * error. At that point, it's almost certainly an error in the underlying
-     * cryptographic library. But, since it is mathematically possible, we use
+     * cryptographic library. But, since it is theoretically possible, we use
      * a fatal error here instead of aborting on a failed assertion.
      */
     if (memcmp(ivA, ivB, ivLen) == 0) {

--- a/src/pisces/holdbuf.c
+++ b/src/pisces/holdbuf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -32,10 +32,10 @@ struct holdbuf {
 struct holdbuf *holdbuf_alloc(size_t stopSize)
 {
     struct holdbuf *ret = calloc(1, sizeof(struct holdbuf));
-    ASSERT_ALLOC(ret);
+    GUARD_ALLOC(ret);
 
     ret->buf = calloc(1, stopSize);
-    ASSERT_ALLOC(ret->buf);
+    GUARD_ALLOC(ret->buf);
     ret->stopSize = stopSize;
 
     return ret;

--- a/src/pisces/iowrap.c
+++ b/src/pisces/iowrap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -42,7 +42,10 @@ int open_input_file(const char *inputFile)
     }
 
 isErr:
-    return errVal ? -1 : inFile;
+    if (errVal) {
+        return errVal;
+    }
+    return inFile;
 }
 
 int open_output_file(const char *outputFile)
@@ -62,7 +65,10 @@ int open_output_file(const char *outputFile)
     }
 
 isErr:
-    return errVal ? -1 : outFile;
+    if (errVal) {
+        return errVal;
+    }
+    return outFile;
 }
 
 int read_exactly(int fd, byte_t *buf, size_t nBytes)
@@ -78,7 +84,7 @@ int read_exactly(int fd, byte_t *buf, size_t nBytes)
     }
 
 isErr:
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 int read_up_to(int fd, byte_t *buf, size_t nBytes, size_t *numRead)
@@ -101,7 +107,7 @@ int read_up_to(int fd, byte_t *buf, size_t nBytes, size_t *numRead)
     }
 
 isErr:
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 int write_exactly(int fd, const byte_t *buf, size_t nBytes)
@@ -119,5 +125,5 @@ int write_exactly(int fd, const byte_t *buf, size_t nBytes)
     }
 
 isErr:
-    return errVal ? -1 : 0;
+    return errVal;
 }

--- a/src/pisces/password.c
+++ b/src/pisces/password.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -87,7 +87,7 @@ isErr:
     scrub_memory(input2, PASSWORD_LENGTH_MAX);
     scrub_memory(&len1, sizeof(size_t));
     scrub_memory(&len2, sizeof(size_t));
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 int get_decryption_password(char *password, size_t *passwordLen,
@@ -113,7 +113,7 @@ int get_decryption_password(char *password, size_t *passwordLen,
 isErr:
     scrub_memory(input, PASSWORD_LENGTH_MAX);
     scrub_memory(&len, sizeof(size_t));
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static int use_provided_password(char *password, size_t *passwordLen,
@@ -127,7 +127,7 @@ static int use_provided_password(char *password, size_t *passwordLen,
     memcpy(password, providedPassword, *passwordLen);
 
 isErr:
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static int password_strlen(const char *provided, size_t *passwordLen)
@@ -150,7 +150,7 @@ static int password_strlen(const char *provided, size_t *passwordLen)
 
 isErr:
     scrub_memory(&len, sizeof(size_t));
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static int get_secret_input(const char *prompt, char *userInput,
@@ -210,5 +210,5 @@ static int get_secret_input(const char *prompt, char *userInput,
 isErr:
     scrub_memory(&c, sizeof(int));
     scrub_memory(&len, sizeof(size_t));
-    return errVal ? -1 : 0;
+    return errVal;
 }

--- a/src/pisces/password.c
+++ b/src/pisces/password.c
@@ -171,7 +171,7 @@ static int get_secret_input(const char *prompt, char *userInput,
 
     fp = fopen(ctermid(NULL), "r+");
     if (fp == NULL) {
-        ERROR(isErr, errVal, "Could not open terminal for reading");
+        FATAL_ERROR("Could not open terminal for reading");
     }
     fprintf(fp, "%s", prompt);
     setbuf(fp, NULL);

--- a/src/pisces/pisces.c
+++ b/src/pisces/pisces.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 isErr:
     scrub_memory(password, PASSWORD_LENGTH_MAX);
     scrub_memory(&passwordLen, sizeof(size_t));
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static void parse_command_line(int argc, char **argv, int *encrypt,
@@ -209,7 +209,7 @@ static int check_files(char *inputFile, char *outputFile)
     }
 
 isErr:
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static void usage(void)

--- a/src/pisces/version.c
+++ b/src/pisces/version.c
@@ -55,7 +55,7 @@ struct cipher_ctx *pisces_unpadded_cipher_alloc(void)
     case 5:
         return cipher_alloc(CIPHER_ALG_AES_256_CBC_NOPAD);
     default:
-        FATAL_ERROR("Illegal Pisces version");
+        ASSERT_NEVER_REACH("Illegal Pisces version");
     }
 }
 
@@ -69,7 +69,7 @@ struct cipher_ctx *pisces_padded_cipher_alloc(void)
     case 5:
         return cipher_alloc(CIPHER_ALG_AES_256_CBC_PKCS7PAD);
     default:
-        FATAL_ERROR("Illegal Pisces version");
+        ASSERT_NEVER_REACH("Illegal Pisces version");
     }
 }
 
@@ -83,7 +83,7 @@ struct chf_ctx *pisces_chf_alloc(void)
     case 5:
         return chf_alloc(CHF_ALG_SHA3_512);
     default:
-        FATAL_ERROR("Illegal Pisces version");
+        ASSERT_NEVER_REACH("Illegal Pisces version");
     }
 }
 
@@ -97,6 +97,6 @@ struct kdf *pisces_kdf_alloc(void)
     case 5:
         return kdf_alloc(KDF_ALG_PBKDF2_HMAC_SHA3_512_16384);
     default:
-        FATAL_ERROR("Illegal Pisces version");
+        ASSERT_NEVER_REACH("Illegal Pisces version");
     }
 }

--- a/src/pisces/version.c
+++ b/src/pisces/version.c
@@ -37,7 +37,7 @@ int pisces_set_version(int version)
     piscesVersion = version;
 
 isErr:
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 int pisces_get_version(void)

--- a/src/pwgen/ascii.c
+++ b/src/pwgen/ascii.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -32,7 +32,7 @@ void get_ascii(char *result, size_t num)
     /* Allocate a temporary array to store raw random bytes */
     remaining = num;
     randArray = (byte_t *)malloc(num);
-    ASSERT_ALLOC(randArray);
+    GUARD_ALLOC(randArray);
     rng = cprng_alloc_default();
 
     /*
@@ -67,7 +67,7 @@ void get_alpha_num(char *result, size_t num)
     /* Allocate a temporary array to store raw random bytes */
     remaining = num;
     randArray = (byte_t *)malloc(num);
-    ASSERT_ALLOC(randArray);
+    GUARD_ALLOC(randArray);
     rng = cprng_alloc_default();
 
     /*

--- a/src/pwgen/hex.c
+++ b/src/pwgen/hex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -53,7 +53,7 @@ static void get_hex_chars(char *result, size_t num, char tenChar)
         rawSize++;
     }
     randArray = (byte_t *)malloc(rawSize);
-    ASSERT_ALLOC(randArray);
+    GUARD_ALLOC(randArray);
 
     /*
      * Generate random bytes and convert to characters.  We get two unbiased

--- a/src/pwgen/pwgen.c
+++ b/src/pwgen/pwgen.c
@@ -91,7 +91,7 @@ isErr:
         scrub_memory(password, length);
         free(password);
     }
-    return errVal ? -1 : 0;
+    return errVal;
 }
 
 static void parse_command_line(int argc, char **argv, size_t *outputLen,

--- a/src/pwgen/pwgen.c
+++ b/src/pwgen/pwgen.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
     /* Allocate memory to hold the generated password */
     ASSERT(length + 1 > length, "Overflow should never happen");
     password = (char *)calloc(length + 1, sizeof(char));
-    ASSERT_ALLOC(password);
+    GUARD_ALLOC(password);
 
     /* Generate the password and output it */
     genFn(password, length);

--- a/src/pwgen/usq.c
+++ b/src/pwgen/usq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023 Ryan Vogt <rvogt.ca@gmail.com>
+ * Copyright (c) 2008-2025 Ryan Vogt <rvogt.ca@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -65,7 +65,7 @@ static void get_usq_simple_cprng(char *result, size_t num, struct cprng *rng)
     /* Allocate a temporary array to store raw random bytes */
     remaining = num;
     randArray = (byte_t *)malloc(num);
-    ASSERT_ALLOC(randArray);
+    GUARD_ALLOC(randArray);
 
     /*
      * Generate random bytes and convert to characters.  Since there are 72


### PR DESCRIPTION
Differentiate between fatal errors and failed assertions, and improve the readability of the macros that provide for those checks.